### PR TITLE
[mongo_connector.py] Allow __exit__ to take arbitrary number of arguments

### DIFF
--- a/src/models/mongo_connector.py
+++ b/src/models/mongo_connector.py
@@ -31,5 +31,5 @@ class MongoConnector:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, *_):
         self.db.close()


### PR DESCRIPTION
Runtime context `__exit__` methods are supposed to take 4 positional arguments.

This should avoid errors like [this one](https://discord.com/channels/754072197135597749/889509483376701450/918443233221169203) (Discord link) to be reported again.